### PR TITLE
Update pcap-sita.c

### DIFF
--- a/jni/libpcap-1.3.0/pcap-sita.c
+++ b/jni/libpcap-1.3.0/pcap-sita.c
@@ -412,8 +412,8 @@ static char *translate_IOP_to_pcap_name(unit_t *u, char *IOPname, bpf_u_int32 if
 	iface_t		*iface_ptr, *iface;
 	char		*name;
 	char		buf[32];
-	char		*proto;
-	char		*port;
+	char		*proto = NULL;
+	char		*port = NULL;
 	int			IOPportnum = 0;
 
 	iface = malloc(sizeof(iface_t));		/* get memory for a structure */


### PR DESCRIPTION
```
Checking ./jni/libpcap-1.3.0/pcap-sita.c…
[./jni/libpcap-1.3.0/pcap-sita.c:448]: (error) Uninitialized variable: proto
[./jni/libpcap-1.3.0/pcap-sita.c:448]: (error) Uninitialized variable: port
52/70 files checked 75% done
```

**It's always good to initialize pointers, [at least to NULL](http://stackoverflow.com/a/18560372), because if you try to dereference the pointer before it gets assigned any actual (non-garbage) value, then you run the risk of dereferencing a garbage address that might cause your program to crash, or worse, might corrupt memory.**

Found by https://github.com/bryongloden/cppcheck
